### PR TITLE
Handle non-ASCII documents and JSON outputs

### DIFF
--- a/pdfreader/lib/book.py
+++ b/pdfreader/lib/book.py
@@ -1,4 +1,4 @@
-from cStringIO import StringIO
+from io import StringIO
 from bs4 import BeautifulSoup
 from page import page
 import json
@@ -26,15 +26,15 @@ class book(object):
         return array
 
     def toJson(self):
-        return json.dumps(self.toDict())
+        return json.dumps(self.toDict(), indent=4)
 
-    def __str__(self):
+    def get(self):
         string = StringIO()
         count = 0
         for p in self._pages:
             if count != 0:
-                string.write('NEW PAGE')
-            string.write(str(p))
+                string.write(u'NEW PAGE')
+            string.write(p.get())
             count = 1
         return string.getvalue()
 

--- a/pdfreader/lib/char.py
+++ b/pdfreader/lib/char.py
@@ -27,7 +27,9 @@ class char(object):
         return self._y
 
     def __init__(self, xml_char):
-        self._font = xml_char.get('font').split('+')[1] if xml_char.get('font') != None else None
+        self._font = xml_char.get('font') if xml_char.get('font') != None else None
+        if self._font is not None and '+' in self._font:
+            self._font = self._font.split('+')[1] 
         if self._font is not None:
             (left, top, self._width, self._height) = xml_char.get('bbox').split(',')
             self._width = int(float(self._width))

--- a/pdfreader/lib/char.py
+++ b/pdfreader/lib/char.py
@@ -8,7 +8,7 @@ class char(object):
     _font = None
     _isBold = False
     _isItalic = False
-    _char = ''
+    _char = u''
 
     @property
     def font(self):
@@ -41,7 +41,8 @@ class char(object):
             self._isItalic = True if len(self._font.split('-')) == 2 and 'Italic' in self._font.split('-')[1] else False
             self._font = self._font.split('-')[0]
             #
-            self._char = xml_char.string
+            self._char = unicode(xml_char.string)
+
 
     def isBold(self):
         return self._isBold
@@ -49,11 +50,8 @@ class char(object):
     def isItalic(self):
         return self._isItalic
 
-    def __str__(self):
+    def get(self):
         if self._font is None:
-            return ""
-        try:
-            char = str(self._char)
-            return char
-        except UnicodeEncodeError:
-            return ""
+            return u""
+        return self._char
+

--- a/pdfreader/lib/line.py
+++ b/pdfreader/lib/line.py
@@ -1,4 +1,4 @@
-from cStringIO import StringIO
+from io import StringIO
 from char import char
 
 class line(object):
@@ -38,6 +38,7 @@ class line(object):
         self._chars = []
         for c in xml_string:
             self._chars.append(char(c))
+
         #
         self._font = self._chars[0].font if len(self._chars) > 0 else None
         self._size = self._chars[0].size if len(self._chars) > 0 else None
@@ -45,28 +46,28 @@ class line(object):
     _italic_on = False
     def handle_italic(self, c, string):
         if self._italic_on is False and c.isItalic() is True:
-            string.write('<i>')
+            string.write(u'<i>')
             self._italic_on = True
         if self._italic_on is True and c.isItalic() is False:
-            string.write('</i>')
+            string.write(u'</i>')
             self._italic_on = False
 
     _bold_on = False
     def handle_bold(self, c, string):
         if self._bold_on is False and c.isBold() is True:
-            string.write('<b>')
+            string.write(u'<b>')
             self._bold_on = True
         if self._bold_on is True and c.isBold() is False:
-            string.write('</b>')
+            string.write(u'</b>')
             self._bold_on = False
 
 
-    def __str__(self):
+    def get(self):
         string = StringIO()
         for c in self._chars:
             self.handle_italic(c, string)
             self.handle_bold(c, string)
-            string.write(str(c))
+            string.write(c.get())
         return string.getvalue()
 
 

--- a/pdfreader/lib/page.py
+++ b/pdfreader/lib/page.py
@@ -1,5 +1,5 @@
 from paragraph import paragraph
-from cStringIO import StringIO
+from io import StringIO
 
 class page(object):
 
@@ -23,13 +23,13 @@ class page(object):
         return array
 
 
-    def __str__(self):
+    def get(self):
         string = StringIO()
         count = 0
         for p in self._paragraphs:
             if count != 0:
-                string.write("\n\n")
-            string.write(str(p))
+                string.write(u"\n\n")
+            string.write(p.get())
             count = 1
         return string.getvalue()
 

--- a/pdfreader/lib/paragraph.py
+++ b/pdfreader/lib/paragraph.py
@@ -1,5 +1,5 @@
 from line import line
-from cStringIO import StringIO
+from io import StringIO
 
 class paragraph(object):
 
@@ -53,19 +53,19 @@ class paragraph(object):
         count = 0
         for l in self._lines:
             if count != 0:
-                string.write("\n")
-            string.write(str(l))
+                string.write(u"\n")
+            string.write(l.get())
             count = 1
         dico.update({'string': string.getvalue()})
         return dico
 
-    def __str__(self):
+    def get(self):
         string = StringIO()
         count = 0
         for l in self._lines:
             if count != 0:
-                string.write("\n")
-            string.write(str(l))
+                string.write(u"\n")
+            string.write(l.get())
             count = 1
         return string.getvalue()
 

--- a/pdfreader/main.py
+++ b/pdfreader/main.py
@@ -77,13 +77,13 @@ def get_images_update_dict(dict_book, image_folder):
     return dict_book
 
 
-def run(pdf_file, image_folder):
+def run(pdf_file, image_folder, codec='utf-8'):
     print "Reading PDF"
     dict_book = text_to_dict(pdf_file)
     print "Extracting images"
     extract_images(pdf_file)
     dict_book = get_images_update_dict(dict_book, image_folder)
-    return json.dumps(dict_book)
+    return json.dumps(dict_book, indent=2, ensure_ascii=False).encode(codec)
 
 
 if __name__ == '__main__':

--- a/pdfreader/util/convert.py
+++ b/pdfreader/util/convert.py
@@ -18,7 +18,7 @@ class converter(object):
                '[-Y layout_mode] [-O output_dir] [-t text|html|xml|tag] [-c codec] [-s scale] file ...' % self._argv[0])
         return 100
 
-    def __init__(self):
+    def __init__(self, codec='utf-8'):
         # debug option
         self._debug = 0
         # input option
@@ -30,7 +30,7 @@ class converter(object):
         self._outtype = None
         self._imagewriter = None
         self._layoutmode = 'normal'
-        self._codec = 'utf-8'
+        self._codec = codec
         self._pageno = 1
         self._scale = 1
         self._caching = True
@@ -139,10 +139,10 @@ class converter(object):
             return usage()
         for fname in self._args:
             fp = file(fname, 'rb')
-	    interpreter = PDFPageInterpreter(rsrcmgr, device)
+            interpreter = PDFPageInterpreter(rsrcmgr, device)
 
             for page in PDFPage.get_pages(fp, self._pagenos, maxpages=self._maxpages, password=self._password, caching=self._caching, check_extractable=True):
-            	interpreter.process_page(page)
+                interpreter.process_page(page)
 
             fp.close()
         device.close()

--- a/psdtools/main.py
+++ b/psdtools/main.py
@@ -100,7 +100,7 @@ class ImportPSD(object):
     @classmethod
     def toJson(self):
         """ Will convert the parsed data array into json """
-        return json.dumps(self.data)
+        return json.dumps(self.data, indent=4)
 
 
 


### PR DESCRIPTION
I'm not sure how the original code could handle UTF-8 input files. Buffering characters in Unicode ensured I could convert mine, producing UTF-8 JSON output (io.cStringIO does accept Unicode while cStringIO doesn't).
This PR also fixes indent inconsistency introduced by the previous PR and a check for bad (malformed?) font names.